### PR TITLE
Fix links for WebSocketBroadcast methods in docs

### DIFF
--- a/apps/docs/content/2.guide/2.custom-events.md
+++ b/apps/docs/content/2.guide/2.custom-events.md
@@ -6,10 +6,10 @@ description: Send custom data to your WebSocket client with C# actions
 ## C# Methods
 You can send custom events to your WebSocket client utilizing these C# methods in Streamer.bot:
 
-::callout{icon=i-mdi-bookmark to=https://docs.streamer.bot/api/csharp/method/WebsocketBroadcastString target=_blank}
+::callout{icon=i-mdi-bookmark to=https://docs.streamer.bot/api/csharp/methods/core/websocket/broadcast-string target=_blank}
 `CPH.WebsocketBroadcastString(string data)`{lang=cs}
 ::
-::callout{icon=i-mdi-bookmark to=https://docs.streamer.bot/api/csharp/method/WebsocketBroadcastJson target=_blank}
+::callout{icon=i-mdi-bookmark to=https://docs.streamer.bot/api/csharp/methods/core/websocket/broadcast-json target=_blank}
 `CPH.WebsocketBroadcastJson(string data)`{lang=cs}
 ::
 


### PR DESCRIPTION
Updated links for C# methods related to WebSocket broadcasting.